### PR TITLE
fix disappearing images in image viewhelper (1 hour after cache clear)

### DIFF
--- a/Classes/Persistence/Generic/Mapper/DataMapFactory.php
+++ b/Classes/Persistence/Generic/Mapper/DataMapFactory.php
@@ -251,6 +251,7 @@ class DataMapFactory implements \TYPO3\CMS\Core\SingletonInterface
      */
     protected function getColumnsDefinition($tableName)
     {
+        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::loadExtTables();
         return is_array($GLOBALS['TCA'][$tableName]['columns']) ? $GLOBALS['TCA'][$tableName]['columns'] : [];
     }
 


### PR DESCRIPTION
Fix bug in extbase core extension to prevent images from not being loaded into the viewhelper (starting 1 hour after clearing both cache_core and cf_extbase_datamapfactory_datamap)